### PR TITLE
Resolve Deployment Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+docs/.vuepress/dist/

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 npm run docs:build
 cd docs/.vuepress/dist
-git init
+git init --initial-branch=main
 git add -A
 git commit -m 'deploy'
 git push -f git@github.com:g5search/opex-runbook.git main:gh-pages


### PR DESCRIPTION
Could not deploy - error message:

```
error: src refspec main does not match any
error: failed to push some refs to 'github.com:g5search/opex-runbook.git'
```

My temp repos default branch was 'master' so failed to deploy - this resolves 